### PR TITLE
Add check for duplicate members in batch update

### DIFF
--- a/octavia/api/v2/controllers/member.py
+++ b/octavia/api/v2/controllers/member.py
@@ -31,6 +31,7 @@ from octavia.common import data_models
 from octavia.common import exceptions
 from octavia.common import validate
 from octavia.db import prepare as db_prepare
+from octavia.i18n import _
 
 
 LOG = logging.getLogger(__name__)
@@ -366,12 +367,21 @@ class MembersController(MemberController):
             # Find members that are brand new or updated
             new_members = []
             updated_members = []
+            updated_member_uniques = set()
             for m in members:
-                if (m.address, m.protocol_port) not in old_member_uniques:
+                key = (m.address, m.protocol_port)
+                if key not in old_member_uniques:
                     validate.ip_not_reserved(m.address)
                     new_members.append(m)
                 else:
-                    m.id = old_member_uniques[(m.address, m.protocol_port)]
+                    m.id = old_member_uniques[key]
+                    if key in updated_member_uniques:
+                        LOG.error("Member %s is updated multiple times in "
+                                  "the same batch request.", m.id)
+                        raise exceptions.ValidationException(
+                            detail=_("Member must be updated only once in the "
+                                     "same request."))
+                    updated_member_uniques.add(key)
                     updated_members.append(m)
 
             # Find members that are deleted

--- a/releasenotes/notes/fix-error-with-duplicate-members-in-batch-update-610ffbbf949927d0.yaml
+++ b/releasenotes/notes/fix-error-with-duplicate-members-in-batch-update-610ffbbf949927d0.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Added a validation step in the batch member API request that checks if a
+    member is included multiple times in the list of updated members, this
+    additional check prevents the load balancer from being stuck in
+    PENDING_UPDATE. Duplicate members in the batch member flow triggered an
+    exception in Taskflow.
+    The API now returns 400 (ValidationException) if a member is already
+    present in the body of the request.


### PR DESCRIPTION
If a user requests a batch update of the members and includes the same member twice in the body of the request, taskflow triggers an exception (because of a duplicate Atom) and the load balancer is stuck in PENDING_UPDATE. Now the API denies such calls and returns a ValidationException if a member is updated more than once in the same call.

Story 2010399
Task 46777

Change-Id: Ide2d5e637e5feb2dad43f952d5be1a195da1ae37 (cherry picked from commit d7b090702523cb07ae4aed0338f9e80fe30791a6) (cherry picked from commit b61c340b096f0a2a90a7db8209639da11e25a4c6)