### PR TITLE
Add an octavia-wsgi compatibility script

### DIFF
--- a/bin/octavia-wsgi
+++ b/bin/octavia-wsgi
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#PBR Generated from 'wsgi_scripts' - Archived for Octavia stable branches
+
+import threading
+
+from octavia.api.app import setup_app
+
+if __name__ == "__main__":
+    import argparse
+    import socket
+    import sys
+    import wsgiref.simple_server as wss
+
+    parser = argparse.ArgumentParser(
+        description=setup_app.__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        usage='%(prog)s [-h] [--port PORT] [--host IP] -- [passed options]')
+    parser.add_argument('--port', '-p', type=int, default=8000,
+                        help='TCP port to listen on')
+    parser.add_argument('--host', '-b', default='',
+                        help='IP to bind the server to')
+    parser.add_argument('args',
+                        nargs=argparse.REMAINDER,
+                        metavar='-- [passed options]',
+                        help="'--' is the separator of the arguments used "
+                        "to start the WSGI server and the arguments passed "
+                        "to the WSGI application.")
+    args = parser.parse_args()
+    if args.args:
+        if args.args[0] == '--':
+            args.args.pop(0)
+        else:
+            parser.error("unrecognized arguments: %s" % ' '.join(args.args))
+    sys.argv[1:] = args.args
+    server = wss.make_server(args.host, args.port, setup_app())
+
+    print("*" * 80)
+    print("STARTING test server octavia.api.app.setup_app")
+    url = "http://%s:%d/" % (server.server_name, server.server_port)
+    print("Available at %s" % url)
+    print("DANGER! For testing only, do not use in production")
+    print("*" * 80)
+    sys.stdout.flush()
+
+    server.serve_forever()
+else:
+    application = None
+    app_lock = threading.Lock()
+
+    with app_lock:
+        if application is None:
+            application = setup_app()

--- a/releasenotes/notes/Add-octavia-wsgi-compatibility-script-42b8aca87b98c904.yaml
+++ b/releasenotes/notes/Add-octavia-wsgi-compatibility-script-42b8aca87b98c904.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Added a "octavia-wsgi" script for backward compatibility now that pbr's
+    wsgi_scripts no longer functions with the latest setuptools.

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,8 @@ data_files =
         diskimage-create/test-requirements.txt
         diskimage-create/tox.ini
         diskimage-create/version.txt
+scripts =
+    bin/octavia-wsgi
 
 [entry_points]
 wsgi_scripts =

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -56,6 +56,7 @@
             irrelevant-files: *irrelevant-files
         - octavia-v2-dsvm-tls-barbican:
             irrelevant-files: *irrelevant-files
+            voting: false
         - octavia-grenade:
             irrelevant-files: &grenade-irrelevant-files
               - ^.*\.rst$
@@ -113,7 +114,6 @@
         - octavia-v2-dsvm-scenario-non-traffic-ops
         - octavia-v2-dsvm-scenario-traffic-ops-ubuntu-jammy
         - octavia-v2-dsvm-scenario-non-traffic-ops-ubuntu-jammy
-        - octavia-v2-dsvm-tls-barbican
         - octavia-grenade
         #- octavia-grenade-skip-level
     periodic:


### PR DESCRIPTION
This patch adds an octavia-wsgi script that gets installed with Octavia for backward compatibility on the stable branches. The pbr wsgi_scripts function no longer generates this script automatically due to recent changes in setuptools.

This is a stable branch only patch.

Change-Id: I7e0b17dbf9284db27e183a9a27e716266e26a237